### PR TITLE
Release/dual and cross ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 env:
    global:
-     - CONAN_REFERENCE: "cmake-installer/1.0"
      - CONAN_USERNAME: "conan"
      - CONAN_LOGIN_USERNAME: "lasote"
      - CONAN_CHANNEL: "testing"
@@ -22,7 +21,7 @@ matrix:
    include:
       - <<: *linux
       - <<: *osx
-        osx_image: xcode8.3
+        osx_image: xcode9
 
 install:
   - chmod +x .travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ env:
      - CONAN_LOGIN_USERNAME: "lasote"
      - CONAN_CHANNEL: "testing"
      - CONAN_UPLOAD: "https://api.bintray.com/conan/conan-community/conan"
-     - CONAN_STABLE_BRANCH_PATTERN: "release/*"
-     - CONAN_UPLOAD_ONLY_WHEN_STABLE: 1 # Will only upload when the branch matches "release/*"
+     - CONAN_STABLE_BRANCH_PATTERN: "master"
+     - CONAN_UPLOAD_ONLY_WHEN_STABLE: 1 # Will only upload when the branch matches "master"
 
 linux: &linux
    os: linux

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@
 
 ## Reference
 
-**cmake_installer/1.0@conan/stable**
+**cmake_installer/XXX@conan/stable**
 
+The available versions are:
+
+   3.10.0, 3.9.0, 3.8.2, 3.8.1, 3.8.0, 3.7.2, 3.7.1, 3.7.0, 3.6.3, 3.6.2, 3.6.1, 3.6.0, 3.5.2, 3.4.3, 3.3.2, 3.2.3, 3.1.3, 3.0.2, 2.8.12
 
 ## Use as a build require
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
     PYTHON_VERSION: "2.7.8"
     PYTHON_ARCH: "32"
 
-    CONAN_REFERENCE: "cmake_installer/1.0"
     CONAN_USERNAME: "conan"
     CONAN_LOGIN_USERNAME: "lasote"
     CONAN_CHANNEL: "testing"

--- a/build.py
+++ b/build.py
@@ -9,9 +9,20 @@ available_versions = ["3.10.0", "3.9.0", "3.8.2",
                       "3.2.3", "3.1.3", "3.0.2", "2.8.12"]
 
 if __name__ == "__main__":
-    builder = ConanMultiPackager()
+
+    # New mode, with version field
+    for version in available_versions:
+        builder = ConanMultiPackager(reference="cmake_installer/%s" % version)
+        # Unknown problem with 3.0.2 on travis
+        if version > "3.0.2" or platform.system() == "Windows":
+            builder.add({}, {}, {}, {})
+        builder.run()
+
+    # Old mode, with options
+    builder = ConanMultiPackager(reference="cmake_installer/1.0")
     for version in available_versions:
         # Unknown problem with 3.0.2 on travis
         if version > "3.0.2" or platform.system() == "Windows":
             builder.add({}, {"cmake_installer:version": version}, {}, {})
     builder.run()
+

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -11,4 +11,9 @@ class ConanFileInst(conans.ConanFile):
         output = StringIO.StringIO()
         self.run("cmake --version", output=output)
         self.output.info("Installed: %s" % str(output.getvalue()))
-        assert(str(self.options["cmake_installer"].version) in str(output.getvalue()))
+        if self.requires["cmake_installer"].conan_reference.version != "1.0":
+            ver = str(self.requires["cmake_installer"].conan_reference.version)
+        else:
+            ver = str(self.options["cmake_installer"].version)
+
+        assert(ver in str(output.getvalue()))


### PR DESCRIPTION
#5 Now that conan supports no specify "version" in the conanfile and package tools should work specifying the complete reference in the "conan create", it's no longer necessary to have different branches to support many versions.
Also prepared to work with the new `os_build` and `os_arch` for the next Conan 1.0