### PR TITLE
added CMake 3.11.0-rc1

### DIFF
--- a/build.py
+++ b/build.py
@@ -2,7 +2,7 @@ import platform
 
 from conan.packager import ConanMultiPackager
 
-available_versions = ["3.10.0", "3.9.0", "3.8.2",
+available_versions = ["3.11.0-rc1", "3.10.0", "3.9.0", "3.8.2",
                       "3.8.1", "3.8.0", "3.7.2", "3.7.1",
                       "3.7.0", "3.6.3", "3.6.2", "3.6.1",
                       "3.6.0", "3.5.2", "3.4.3", "3.3.2",

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import tools, ConanFile
 from conans import __version__ as conan_version
 from conans.model.version import Version
 
-available_versions = ["3.10.0", "3.9.0", "3.8.2",
+available_versions = ["3.11.0-rc1", "3.10.0", "3.9.0", "3.8.2",
                       "3.8.1", "3.8.0", "3.7.2", "3.7.1",
                       "3.7.0", "3.6.3", "3.6.2", "3.6.1",
                       "3.6.0", "3.5.2", "3.4.3", "3.3.2",
@@ -21,7 +21,7 @@ class CMakeInstallerConan(ConanFile):
     else:
         settings = "os_build", "arch_build"
     options = {"version": available_versions}
-    default_options = "version=" + available_versions[0]
+    default_options = "version=3.10.0"
     build_policy = "missing"
 
     def minor_version(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,7 +21,7 @@ class CMakeInstallerConan(ConanFile):
     else:
         settings = "os_build", "arch_build"
     options = {"version": available_versions}
-    default_options = "version=3.10.0"
+    default_options = "version=" + [v for v in available_versions if "-" not in v][0]
     build_policy = "missing"
 
     def minor_version(self):


### PR DESCRIPTION
Keeping CMake 3.10 as default. Tested only on Windows.
python 2.7
conan 1.0.4
conan-package tools 0.13.0
CMake 3.11.0-rc1